### PR TITLE
Update Cookie.php

### DIFF
--- a/Cookie.php
+++ b/Cookie.php
@@ -117,7 +117,7 @@ class Cookie
 	 * @param string $name
 	 * @return string
 	 */
-	public function realname($name)
+	public static function realname($name)
 	{
 		return self::$prefix . $name;
 	}


### PR DESCRIPTION
Strict Standards: Non-static method Cookie::realname() should not be called statically in /behigh/Cookie/Cookie.php on line 190
